### PR TITLE
Add the stitch Wasm runtime to the set of tested VMs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1363,6 +1363,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "makepad-stitch"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa7ba762e43513e765ad4d15adfbc5e7456f3e59d357fb0a36fe3efa6e560159"
+
+[[package]]
 name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2684,6 +2690,7 @@ name = "wasmi-benchmarks"
 version = "0.1.0"
 dependencies = [
  "criterion",
+ "makepad-stitch",
  "serde_json",
  "tinywasm",
  "wasm3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ wasmer = { version = "4.3", default-features = false, features = ["engine", "com
 wasmer-compiler-singlepass = "4.3"
 wasmer-compiler-cranelift = "4.3"
 wasmtime = { version = "20.0", default-features = false, features = ["winch", "cranelift", "runtime"] }
+makepad-stitch = "0.1.0"
 criterion = "0.5"
 wat = "1"
 serde_json = "1.0.117"
@@ -39,6 +40,9 @@ harness = false
 # debug = true
 lto = "fat"
 codegen-units = 1
+
+[profile.dev]
+opt-level = 1 # required for the stitch Wasm runtime's LLVM's sibling calls optimization
 
 [profile.wasm]
 # The profile used to build Rust based benchmark inputs to WebAssembly.

--- a/src/vms/mod.rs
+++ b/src/vms/mod.rs
@@ -1,3 +1,4 @@
+pub use self::stitch::Stitch;
 pub use self::tinywasm::Tinywasm;
 pub use self::wasm3::Wasm3;
 pub use self::wasmer::Wasmer;
@@ -7,6 +8,7 @@ pub use self::wasmtime::Wasmtime;
 use crate::utils::TestFilter;
 use ::wasmi_new::ModuleImportsIter;
 
+mod stitch;
 mod tinywasm;
 mod wasm3;
 mod wasmer;
@@ -74,6 +76,7 @@ pub fn vms_under_test() -> Vec<Box<dyn BenchVm>> {
         Box::new(Wasm3 {
             compilation_mode: wasm3::CompilationMode::Lazy,
         }),
+        Box::new(Stitch),
         Box::new(Wasmtime {
             strategy: ::wasmtime::Strategy::Cranelift,
         }),

--- a/src/vms/stitch.rs
+++ b/src/vms/stitch.rs
@@ -1,0 +1,87 @@
+use crate::{CompileTestFilter, ExecuteTestFilter, TestFilter};
+
+use super::{elapsed_ms, BenchRuntime, BenchVm};
+use core::slice;
+use makepad_stitch::{Engine, ExternVal, Func, Instance, Linker, Module, Store, Val};
+use wasmi_new::ModuleImportsIter;
+
+pub struct Stitch;
+
+struct StitchRuntime {
+    store: Store,
+    _instance: Instance,
+    func: Func,
+}
+
+impl BenchVm for Stitch {
+    fn name(&self) -> &'static str {
+        "stitch"
+    }
+
+    fn test_filter(&self) -> TestFilter {
+        TestFilter {
+            execute: ExecuteTestFilter {
+                fib_tailrec: false, // stich does not yet support tail calls
+                argon2: false,      // stitch currently seems to have a bug while executing
+                ..ExecuteTestFilter::default()
+            },
+            compile: CompileTestFilter {
+                ffmpeg: false, // function body too large for stitch
+                // argon2: false, // stitch currently seems to have a bug while executing
+                ..CompileTestFilter::default()
+            },
+        }
+    }
+
+    fn compile(&self, wasm: &[u8], _imports: ModuleImportsIter) {
+        let engine = Engine::new();
+        Module::new(&engine, wasm).unwrap();
+    }
+
+    fn load(&self, wasm: &[u8]) -> Box<dyn BenchRuntime> {
+        let engine = Engine::new();
+        let mut store = Store::new(engine);
+        let engine = store.engine();
+        let module = Module::new(engine, wasm).unwrap();
+        let linker = Linker::new();
+        let instance = linker.instantiate(&mut store, &module).unwrap();
+        let func = instance.exported_func("run").unwrap();
+        Box::new(StitchRuntime {
+            store,
+            _instance: instance,
+            func,
+        })
+    }
+
+    fn coremark(&self, wasm: &[u8]) -> f32 {
+        let engine = Engine::new();
+        let mut store = Store::new(engine);
+        let engine = store.engine();
+        let module = Module::new(engine, wasm).unwrap();
+        let mut linker = Linker::new();
+        linker.define(
+            "env",
+            "clock_ms",
+            ExternVal::Func(Func::wrap(&mut store, elapsed_ms)),
+        );
+        let instance = linker.instantiate(&mut store, &module).unwrap();
+        let func = instance.exported_func("run").unwrap();
+        let mut result = Val::F32(0.0);
+        func.call(&mut store, &[], slice::from_mut(&mut result))
+            .unwrap();
+        result.to_f32().unwrap()
+    }
+}
+
+impl BenchRuntime for StitchRuntime {
+    fn call(&mut self, input: i64) {
+        let mut result = Val::I64(0);
+        self.func
+            .call(
+                &mut self.store,
+                &[Val::I64(input)],
+                slice::from_mut(&mut result),
+            )
+            .unwrap();
+    }
+}


### PR DESCRIPTION
cc @ejpbruel2 Nice work on your Stitch Wasm runtime, it looks very promising!

Things to look out in this PR:

- We had to add `[profile.dev] opt-level=1` for `stitch` because it heavily relies on LLVM optimizations to even work.
- Stitch currently does not yet support Wasm tail calls, so the associated benchmark got disabled for it.
- The `ffmpeg.wasm` compilation test got disabled because it has function bodies too large for Stitch to handle.
- Stitch seems to have a bug that prevents us from executing the `argon2` benchmark, thus disabled.

It seems that at least on GitHub Actions CI runners the new Wasmi version, Stitch and Wasm3 perform kinda similar.
Though on Mac M2 Stitch heavily outperforms its competition.

Coremark scores from the GitHub Actions CI runner: (`ubuntu-latest`, `AMD Epyc 7763`)
(link: https://github.com/wasmi-labs/wasmi-benchmarks/actions/runs/9093096929/job/24991283242?pr=8#step:7:81)
```json
{
  "stitch": 1294.91748046875,
  "tinywasm": 203.22450256347656,
  "wasm3.eager": 1145.016357421875,
  "wasm3.lazy": 1168.7705078125,
  "wasmer.cranelift": 17630.46484375,
  "wasmer.singlepass": 9585.2216796875,
  "wasmi-v0.31": 676.631591796875,
  "wasmi-v0.32.eager.checked": 1279.344970703125,
  "wasmi-v0.32.eager.unchecked": 1277.3023681640625,
  "wasmi-v0.32.lazy-translation.checked": 1302.1680908203125,
  "wasmi-v0.32.lazy.checked": 1285.181884765625,
  "wasmi-v0.32.lazy.unchecked": 1300.9822998046875,
  "wasmtime.cranelift": 20128.82421875,
  "wasmtime.winch": 20061.521484375
}
```