### PR TITLE
Integrate Wasmtime's Pulley interpreter

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -179,6 +179,9 @@ jobs:
                   ~/target/
                 key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}
                 restore-keys: ${{ runner.os }}-${{ github.job }}-
+            # The fontconfig package is required for the plotters dependency.
+            - name: Install fontconfig
+              run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev
             - name: Checkout Submodules
               run: git submodule update --init --recursive
             - name: Clippy (all features)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,9 @@ jobs:
                 ~/target/
               key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}
               restore-keys: ${{ runner.os }}-${{ github.job }}-
+          # The fontconfig package is required for the plotters dependency.
+          - name: Install fontconfig
+            run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev
           - name: Build (default features)
             run: cargo build --workspace
 
@@ -51,6 +54,9 @@ jobs:
                   ~/target/
                 key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}
                 restore-keys: ${{ runner.os }}-${{ github.job }}-
+            # The fontconfig package is required for the plotters dependency.
+            - name: Install fontconfig
+              run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev
             - name: System Information
               run: lscpu
             - name: Compile (--profile ci)
@@ -76,6 +82,9 @@ jobs:
                   ~/target/
                 key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}
                 restore-keys: ${{ runner.os }}-${{ github.job }}-
+            # The fontconfig package is required for the plotters dependency.
+            - name: Install fontconfig
+              run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev
             - name: System Information
               run: lscpu
             - name: Compile (--profile ci)
@@ -101,6 +110,9 @@ jobs:
                 ~/target/
               key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}
               restore-keys: ${{ runner.os }}-${{ github.job }}-
+          # The fontconfig package is required for the plotters dependency.
+          - name: Install fontconfig
+            run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev
           - name: System Information
             run: lscpu
           - name: Compile (--profile ci)
@@ -139,6 +151,9 @@ jobs:
                   ~/target/
                 key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}
                 restore-keys: ${{ runner.os }}-${{ github.job }}-
+            # The fontconfig package is required for the plotters dependency.
+            - name: Install fontconfig
+              run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev
             - name: Check Docs
               env:
                 RUSTDOCFLAGS: "-D warnings"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,10 +595,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.117.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
+version = "0.116.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4b40a4068a63a834cd7c26ca6d62682934b75689bd0056fc00d06763c09651d"
 dependencies = [
- "cranelift-entity 0.117.0",
+ "cranelift-entity 0.116.0",
 ]
 
 [[package]]
@@ -609,8 +610,9 @@ checksum = "690d8ae6c73748e5ce3d8fe59034dceadb8823e6c8994ba324141c5eae909b0e"
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.117.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
+version = "0.116.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab925581363040c22dc89ac7b9b0825364d0960761002a60a1997f06071633f9"
 dependencies = [
  "serde",
  "serde_derive",
@@ -641,19 +643,20 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.117.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
+version = "0.116.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57cecebb9bdba93c0e15691d74559bbb198fe8d3371e147407b223c751003e0f"
 dependencies = [
  "bumpalo",
- "cranelift-bforest 0.117.0",
- "cranelift-bitset 0.117.0",
- "cranelift-codegen-meta 0.117.0",
- "cranelift-codegen-shared 0.117.0",
- "cranelift-control 0.117.0",
- "cranelift-entity 0.117.0",
- "cranelift-isle 0.117.0",
+ "cranelift-bforest 0.116.0",
+ "cranelift-bitset 0.116.0",
+ "cranelift-codegen-meta 0.116.0",
+ "cranelift-codegen-shared 0.116.0",
+ "cranelift-control 0.116.0",
+ "cranelift-entity 0.116.0",
+ "cranelift-isle 0.116.0",
  "gimli 0.31.1",
- "hashbrown 0.15.2",
+ "hashbrown 0.14.5",
  "log",
  "pulley-interpreter",
  "regalloc2 0.11.1",
@@ -674,10 +677,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.117.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
+version = "0.116.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0791a86ec24d52f3828b10ff63cc0d05103b3a944d6acbd1e8de32291a5ffc"
 dependencies = [
- "cranelift-codegen-shared 0.117.0",
+ "cranelift-codegen-shared 0.116.0",
  "pulley-interpreter",
 ]
 
@@ -689,8 +693,9 @@ checksum = "efcff860573cf3db9ae98fbd949240d78b319df686cc306872e7fab60e9c84d7"
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.117.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
+version = "0.116.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e279f25ee84cc7a067f9e87cfc382c8cf7957362a558fe5d71ac26fabde70d7f"
 
 [[package]]
 name = "cranelift-control"
@@ -703,8 +708,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-control"
-version = "0.117.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
+version = "0.116.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37721e72ce0f738f6c72c33fb702f9fdfba511cc7be58a49e9eb32b5a9d7b46d"
 dependencies = [
  "arbitrary",
 ]
@@ -720,10 +726,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-entity"
-version = "0.117.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
+version = "0.116.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6632a6d2de04256e8fb072ac4a89f6803217780a979c8d254f4cfcd732db86d"
 dependencies = [
- "cranelift-bitset 0.117.0",
+ "cranelift-bitset 0.116.0",
  "serde",
  "serde_derive",
 ]
@@ -742,10 +749,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.117.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
+version = "0.116.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cf22abd6aa1417bf49825a009ba3a6e8512df49dc1dbe7c4ee143b5a6733119"
 dependencies = [
- "cranelift-codegen 0.117.0",
+ "cranelift-codegen 0.116.0",
  "log",
  "smallvec",
  "target-lexicon 0.13.1",
@@ -759,15 +767,17 @@ checksum = "56b08621c00321efcfa3eee6a3179adc009e21ea8d24ca7adc3c326184bc3f48"
 
 [[package]]
 name = "cranelift-isle"
-version = "0.117.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
+version = "0.116.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f0f10ede8c9ffda545a03d823b5dfd6e6b08a5ffc7a2d1f3881b1cd5640a5ee"
 
 [[package]]
 name = "cranelift-native"
-version = "0.117.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
+version = "0.116.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c550ec70cf6a717fc12c535064ba6b19416ec1d011d969e9068664e9b66b5928"
 dependencies = [
- "cranelift-codegen 0.117.0",
+ "cranelift-codegen 0.116.0",
  "libc",
  "target-lexicon 0.13.1",
 ]
@@ -2285,10 +2295,11 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "30.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
+version = "29.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16dd927f534c8b55c0836551123ab18e8620aa42089371733dda5b512486217d"
 dependencies = [
- "cranelift-bitset 0.117.0",
+ "cranelift-bitset 0.116.0",
  "log",
  "sptr",
  "wasmtime-math",
@@ -3241,6 +3252,16 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
+version = "0.221.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17a3bd88f2155da63a1f2fcb8a56377a24f0b6dfed12733bb5f544e86f690c5"
+dependencies = [
+ "leb128",
+ "wasmparser 0.221.2",
+]
+
+[[package]]
+name = "wasm-encoder"
 version = "0.223.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e636076193fa68103e937ac951b5f2f587624097017d764b8984d9c0f149464"
@@ -3544,7 +3565,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9845c470a2e10b61dd42c385839cdd6496363ed63b5c9e420b5488b77bd22083"
 dependencies = [
  "bitflags 2.7.0",
+ "hashbrown 0.15.2",
  "indexmap 2.7.0",
+ "semver",
+ "serde",
 ]
 
 [[package]]
@@ -3554,10 +3578,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5a99faceb1a5a84dd6084ec4bfa4b2ab153b5793b43fd8f58b89232634afc35"
 dependencies = [
  "bitflags 2.7.0",
- "hashbrown 0.15.2",
  "indexmap 2.7.0",
  "semver",
- "serde",
 ]
 
 [[package]]
@@ -3571,26 +3593,27 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.223.0"
+version = "0.221.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9235722b8cdb6c1c6daa537d4be4e230e76ce3ce0e4ba991956a1c6aed50305a"
+checksum = "a80742ff1b9e6d8c231ac7c7247782c6fc5bce503af760bca071811e5fc9ee56"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.223.0",
+ "wasmparser 0.221.2",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "30.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
+version = "29.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb9bf5c0f67bd06d0711f7a5944c662de1d16b43bd274e257738fb916c87d3f"
 dependencies = [
  "anyhow",
  "bitflags 2.7.0",
  "bumpalo",
  "cc",
  "cfg-if 1.0.0",
- "hashbrown 0.15.2",
+ "hashbrown 0.14.5",
  "indexmap 2.7.0",
  "libc",
  "log",
@@ -3608,7 +3631,7 @@ dependencies = [
  "smallvec",
  "sptr",
  "target-lexicon 0.13.1",
- "wasmparser 0.223.0",
+ "wasmparser 0.221.2",
  "wasmtime-asm-macros",
  "wasmtime-component-macro",
  "wasmtime-cranelift",
@@ -3624,16 +3647,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "30.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
+version = "29.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be48dd2c184a2f5ce5f423ad9c2071b15547f0a7b5b0e89aa92893b6b8981670"
 dependencies = [
  "cfg-if 1.0.0",
 ]
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "30.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
+version = "29.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d76f686ba245b5197eaebb5e580fffd2df64f6a33d9718c358e61c3a01a059e"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -3646,20 +3671,22 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "30.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
+version = "29.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2347410b200664a5c62c648556e502c4eb2da5686cb67d7760cf74e9d0b101"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "30.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
+version = "29.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6176d86abc0566fd6719c073650555a5da31d24ec784c65b4fad78c39d5d1fa"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
- "cranelift-codegen 0.117.0",
- "cranelift-control 0.117.0",
- "cranelift-entity 0.117.0",
- "cranelift-frontend 0.117.0",
+ "cranelift-codegen 0.116.0",
+ "cranelift-control 0.116.0",
+ "cranelift-entity 0.116.0",
+ "cranelift-frontend 0.116.0",
  "cranelift-native",
  "gimli 0.31.1",
  "itertools 0.12.1",
@@ -3669,19 +3696,20 @@ dependencies = [
  "smallvec",
  "target-lexicon 0.13.1",
  "thiserror 1.0.69",
- "wasmparser 0.223.0",
+ "wasmparser 0.221.2",
  "wasmtime-environ",
  "wasmtime-versioned-export-macros",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "30.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
+version = "29.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf09f7ec4324917a8a023f841960eb892066e4dfd585dbe9a9646c1d2a74bee"
 dependencies = [
  "anyhow",
- "cranelift-bitset 0.117.0",
- "cranelift-entity 0.117.0",
+ "cranelift-bitset 0.116.0",
+ "cranelift-entity 0.116.0",
  "gimli 0.31.1",
  "indexmap 2.7.0",
  "log",
@@ -3691,15 +3719,16 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "target-lexicon 0.13.1",
- "wasm-encoder",
- "wasmparser 0.223.0",
+ "wasm-encoder 0.221.2",
+ "wasmparser 0.221.2",
  "wasmprinter",
 ]
 
 [[package]]
 name = "wasmtime-fiber"
-version = "30.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
+version = "29.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcc8d43b33f87c32a9d6d000cd22c4f280ebf350610bbaaaca38743cdbfbc2f3"
 dependencies = [
  "anyhow",
  "cc",
@@ -3712,8 +3741,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "30.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
+version = "29.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82391fd51897bd867cae438530acdaff4aa3ddeef7ffc4704a3a73f81a597c6b"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -3723,21 +3753,24 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-math"
-version = "30.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
+version = "29.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9462c2c3590bf81c136343c921a25799baa6ba4ff25aeefe6c6c648b786ab545"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "wasmtime-slab"
-version = "30.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
+version = "29.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8e57bd1a3969f514ccd4809070578ecabcfe7b9ae0bf7caeecbefa5f8e6116a"
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "30.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
+version = "29.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ace164f57911393996f06a7d1c9ad769817e5d4c291e937d2f2460d2fc2f04"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3746,15 +3779,16 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "30.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
+version = "29.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c84e5af31800d7b51e48c6aa1ed4de27a178148aecd087c3f258d53a9dba64a"
 dependencies = [
  "anyhow",
- "cranelift-codegen 0.117.0",
+ "cranelift-codegen 0.116.0",
  "gimli 0.31.1",
  "object 0.36.7",
  "target-lexicon 0.13.1",
- "wasmparser 0.223.0",
+ "wasmparser 0.221.2",
  "wasmtime-cranelift",
  "wasmtime-environ",
  "winch-codegen",
@@ -3762,8 +3796,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "30.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
+version = "29.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adef46f34928715186c0aac094989602c89d1dfea4f28555c964b29b5e7f7bed"
 dependencies = [
  "anyhow",
  "heck",
@@ -3781,7 +3816,7 @@ dependencies = [
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder",
+ "wasm-encoder 0.223.0",
 ]
 
 [[package]]
@@ -3875,17 +3910,18 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "30.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
+version = "29.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afe027e3fcf34c52ea98ecb4ed668a2e5cc8566b8e6381b2bb990c9a7eccdc34"
 dependencies = [
  "anyhow",
- "cranelift-codegen 0.117.0",
+ "cranelift-codegen 0.116.0",
  "gimli 0.31.1",
  "regalloc2 0.11.1",
  "smallvec",
  "target-lexicon 0.13.1",
  "thiserror 1.0.69",
- "wasmparser 0.223.0",
+ "wasmparser 0.221.2",
  "wasmtime-cranelift",
  "wasmtime-environ",
 ]
@@ -4058,9 +4094,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.223.0"
+version = "0.221.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92772f4dcacb804b275981eea1d920b12b377993b53307f1e33d87404e080281"
+checksum = "fbe1538eea6ea5ddbe5defd0dc82539ad7ba751e1631e9185d24a931f0a5adc8"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -4071,7 +4107,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.223.0",
+ "wasmparser 0.221.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,7 @@ version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -209,9 +209,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1be3f42a67d6d345ecd59f675f3f012d6974981560836e938c22b424b85ce1be"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "bitvec"
@@ -366,9 +366,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.9"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8293772165d9345bdaaa39b45b2109591e63fe5e6fbc23c6ff930a048aa310b"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
  "jobserver",
  "libc",
@@ -460,18 +460,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.26"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8eb5e908ef3a6efbe1ed62520fb7287959888c88485abe072543190ecc66783"
+checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.26"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b01801b5fc6a0a232407abc821660c9c6d25a1cafc0d4f85f29fb8d9afc121"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -1215,7 +1215,7 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b64b34f4efd515f905952d91bc185039863705592c0c53ae6d979805dd154520"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "byteorder",
  "core-foundation",
  "core-graphics",
@@ -1327,7 +1327,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 dependencies = [
  "fallible-iterator",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "stable_deref_trait",
 ]
 
@@ -1338,7 +1338,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 dependencies = [
  "fallible-iterator",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "stable_deref_trait",
 ]
 
@@ -1631,9 +1631,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -1770,7 +1770,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "libc",
  "redox_syscall",
 ]
@@ -1805,9 +1805,9 @@ checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "lzma-rs"
@@ -1975,7 +1975,7 @@ dependencies = [
  "crc32fast",
  "flate2",
  "hashbrown 0.14.5",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "memchr",
  "ruzstd",
 ]
@@ -1988,7 +1988,7 @@ checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "crc32fast",
  "hashbrown 0.15.2",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "memchr",
 ]
 
@@ -2385,7 +2385,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -2527,7 +2527,7 @@ dependencies = [
  "bytecheck 0.8.0",
  "bytes",
  "hashbrown 0.15.2",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "munge",
  "ptr_meta 0.3.0",
  "rancor",
@@ -2592,7 +2592,7 @@ version = "0.38.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2683,9 +2683,9 @@ checksum = "c2fdfc24bc566f839a2da4c4295b82db7d25a24253867d5c64355abb5799bdbe"
 
 [[package]]
 name = "semver"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "serde"
@@ -2720,9 +2720,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.135"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
+checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
 dependencies = [
  "itoa",
  "memchr",
@@ -3166,9 +3166,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b913a3b5fe84142e269d63cc62b64319ccaf89b748fc31fe025177f767a756c4"
+checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
 
 [[package]]
 name = "version_check"
@@ -3415,7 +3415,7 @@ dependencies = [
  "enumset",
  "getrandom",
  "hex",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "more-asserts",
  "rkyv 0.8.9",
  "sha2",
@@ -3438,7 +3438,7 @@ dependencies = [
  "dashmap",
  "enum-iterator",
  "fnv",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "lazy_static",
  "libc",
  "mach2",
@@ -3552,9 +3552,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcdee6bea3619d311fb4b299721e89a986c3470f804b6d534340e412589028e3"
 dependencies = [
  "ahash 0.8.11",
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "hashbrown 0.14.5",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "semver",
 ]
 
@@ -3564,9 +3564,9 @@ version = "0.221.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9845c470a2e10b61dd42c385839cdd6496363ed63b5c9e420b5488b77bd22083"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "hashbrown 0.15.2",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "semver",
  "serde",
 ]
@@ -3577,8 +3577,8 @@ version = "0.223.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5a99faceb1a5a84dd6084ec4bfa4b2ab153b5793b43fd8f58b89232634afc35"
 dependencies = [
- "bitflags 2.7.0",
- "indexmap 2.7.0",
+ "bitflags 2.8.0",
+ "indexmap 2.7.1",
  "semver",
 ]
 
@@ -3609,12 +3609,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eb9bf5c0f67bd06d0711f7a5944c662de1d16b43bd274e257738fb916c87d3f"
 dependencies = [
  "anyhow",
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "bumpalo",
  "cc",
  "cfg-if 1.0.0",
  "hashbrown 0.14.5",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "libc",
  "log",
  "mach2",
@@ -3711,7 +3711,7 @@ dependencies = [
  "cranelift-bitset 0.116.0",
  "cranelift-entity 0.116.0",
  "gimli 0.31.1",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "log",
  "object 0.36.7",
  "postcard",
@@ -3802,7 +3802,7 @@ checksum = "adef46f34928715186c0aac094989602c89d1dfea4f28555c964b29b5e7f7bed"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "wit-parser",
 ]
 
@@ -4100,7 +4100,7 @@ checksum = "fbe1538eea6ea5ddbe5defd0dc82539ad7ba751e1631e9185d24a931f0a5adc8"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "log",
  "semver",
  "serde",
@@ -4301,7 +4301,7 @@ dependencies = [
  "displaydoc",
  "flate2",
  "hmac",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "lzma-rs",
  "memchr",
  "pbkdf2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,11 +595,10 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.115.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac89549be94911dd0e839b4a7db99e9ed29c17517e1c026f61066884c168aa3c"
+version = "0.117.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
 dependencies = [
- "cranelift-entity 0.115.0",
+ "cranelift-entity 0.117.0",
 ]
 
 [[package]]
@@ -610,9 +609,8 @@ checksum = "690d8ae6c73748e5ce3d8fe59034dceadb8823e6c8994ba324141c5eae909b0e"
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.115.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9bd49369f76c77e34e641af85d0956869237832c118964d08bf5f51f210875a"
+version = "0.117.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
 dependencies = [
  "serde",
  "serde_derive",
@@ -638,31 +636,31 @@ dependencies = [
  "regalloc2 0.9.3",
  "rustc-hash 1.1.0",
  "smallvec",
- "target-lexicon",
+ "target-lexicon 0.12.16",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.115.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd96ce9cf8efebd7f5ab8ced5a0ce44250280bbae9f593d74a6d7effc3582a35"
+version = "0.117.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
 dependencies = [
  "bumpalo",
- "cranelift-bforest 0.115.0",
- "cranelift-bitset 0.115.0",
- "cranelift-codegen-meta 0.115.0",
- "cranelift-codegen-shared 0.115.0",
- "cranelift-control 0.115.0",
- "cranelift-entity 0.115.0",
- "cranelift-isle 0.115.0",
+ "cranelift-bforest 0.117.0",
+ "cranelift-bitset 0.117.0",
+ "cranelift-codegen-meta 0.117.0",
+ "cranelift-codegen-shared 0.117.0",
+ "cranelift-control 0.117.0",
+ "cranelift-entity 0.117.0",
+ "cranelift-isle 0.117.0",
  "gimli 0.31.1",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
  "log",
+ "pulley-interpreter",
  "regalloc2 0.11.1",
  "rustc-hash 2.1.0",
  "serde",
  "smallvec",
- "target-lexicon",
+ "target-lexicon 0.13.1",
 ]
 
 [[package]]
@@ -676,11 +674,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.115.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a68e358827afe4bfb6239fcbf6fbd5ac56206ece8a99c8f5f9bbd518773281a"
+version = "0.117.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
 dependencies = [
- "cranelift-codegen-shared 0.115.0",
+ "cranelift-codegen-shared 0.117.0",
+ "pulley-interpreter",
 ]
 
 [[package]]
@@ -691,9 +689,8 @@ checksum = "efcff860573cf3db9ae98fbd949240d78b319df686cc306872e7fab60e9c84d7"
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.115.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e184c9767afbe73d50c55ec29abcf4c32f9baf0d9d22b86d58c4d55e06dee181"
+version = "0.117.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
 
 [[package]]
 name = "cranelift-control"
@@ -706,9 +703,8 @@ dependencies = [
 
 [[package]]
 name = "cranelift-control"
-version = "0.115.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc7664f2a66f053e33f149e952bb5971d138e3af637f5097727ed6dc0ed95dd"
+version = "0.117.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
 dependencies = [
  "arbitrary",
 ]
@@ -724,11 +720,10 @@ dependencies = [
 
 [[package]]
 name = "cranelift-entity"
-version = "0.115.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "118597e3a9cf86c3556fa579a7a23b955fa18231651a52a77a2475d305a9cf84"
+version = "0.117.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
 dependencies = [
- "cranelift-bitset 0.115.0",
+ "cranelift-bitset 0.117.0",
  "serde",
  "serde_derive",
 ]
@@ -742,19 +737,18 @@ dependencies = [
  "cranelift-codegen 0.110.2",
  "log",
  "smallvec",
- "target-lexicon",
+ "target-lexicon 0.12.16",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.115.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7638ea1efb069a0aa18d8ee67401b6b0d19f6bfe5de5e9ede348bfc80bb0d8c7"
+version = "0.117.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
 dependencies = [
- "cranelift-codegen 0.115.0",
+ "cranelift-codegen 0.117.0",
  "log",
  "smallvec",
- "target-lexicon",
+ "target-lexicon 0.13.1",
 ]
 
 [[package]]
@@ -765,19 +759,17 @@ checksum = "56b08621c00321efcfa3eee6a3179adc009e21ea8d24ca7adc3c326184bc3f48"
 
 [[package]]
 name = "cranelift-isle"
-version = "0.115.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c53e1152a0b01c4ed2b1e0535602b8e86458777dd9d18b28732b16325c7dc0"
+version = "0.117.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
 
 [[package]]
 name = "cranelift-native"
-version = "0.115.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7d8f895444fa52dd7bdd0bed11bf007a7fb43af65a6deac8fcc4094c6372f7"
+version = "0.117.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
 dependencies = [
- "cranelift-codegen 0.115.0",
+ "cranelift-codegen 0.117.0",
  "libc",
- "target-lexicon",
+ "target-lexicon 0.13.1",
 ]
 
 [[package]]
@@ -2293,13 +2285,13 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403a1a95f4c18a45c86c7bff13df00347afd0abcbf2e54af273c837339ffcf77"
+version = "30.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
 dependencies = [
- "cranelift-bitset 0.115.0",
+ "cranelift-bitset 0.117.0",
  "log",
  "sptr",
+ "wasmtime-math",
 ]
 
 [[package]]
@@ -2895,6 +2887,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
+name = "target-lexicon"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc12939a1c9b9d391e0b7135f72fd30508b73450753e28341fed159317582a77"
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3243,16 +3241,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.221.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17a3bd88f2155da63a1f2fcb8a56377a24f0b6dfed12733bb5f544e86f690c5"
-dependencies = [
- "leb128",
- "wasmparser 0.221.2",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.223.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e636076193fa68103e937ac951b5f2f587624097017d764b8984d9c0f149464"
@@ -3299,7 +3287,7 @@ dependencies = [
  "serde-wasm-bindgen",
  "shared-buffer",
  "tar",
- "target-lexicon",
+ "target-lexicon 0.12.16",
  "thiserror 1.0.69",
  "tracing",
  "ureq",
@@ -3335,7 +3323,7 @@ dependencies = [
  "self_cell",
  "shared-buffer",
  "smallvec",
- "target-lexicon",
+ "target-lexicon 0.12.16",
  "thiserror 1.0.69",
  "wasmer-types",
  "wasmer-vm",
@@ -3358,7 +3346,7 @@ dependencies = [
  "more-asserts",
  "rayon",
  "smallvec",
- "target-lexicon",
+ "target-lexicon 0.12.16",
  "tracing",
  "wasmer-compiler",
  "wasmer-types",
@@ -3410,7 +3398,7 @@ dependencies = [
  "more-asserts",
  "rkyv 0.8.9",
  "sha2",
- "target-lexicon",
+ "target-lexicon 0.12.16",
  "thiserror 1.0.69",
  "xxhash-rust",
 ]
@@ -3556,10 +3544,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9845c470a2e10b61dd42c385839cdd6496363ed63b5c9e420b5488b77bd22083"
 dependencies = [
  "bitflags 2.7.0",
- "hashbrown 0.15.2",
  "indexmap 2.7.0",
- "semver",
- "serde",
 ]
 
 [[package]]
@@ -3569,8 +3554,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5a99faceb1a5a84dd6084ec4bfa4b2ab153b5793b43fd8f58b89232634afc35"
 dependencies = [
  "bitflags 2.7.0",
+ "hashbrown 0.15.2",
  "indexmap 2.7.0",
  "semver",
+ "serde",
 ]
 
 [[package]]
@@ -3584,30 +3571,28 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.221.2"
+version = "0.223.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a80742ff1b9e6d8c231ac7c7247782c6fc5bce503af760bca071811e5fc9ee56"
+checksum = "9235722b8cdb6c1c6daa537d4be4e230e76ce3ce0e4ba991956a1c6aed50305a"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.221.2",
+ "wasmparser 0.223.0",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639ecae347b9a2227e453a7b7671e84370a0b61f47a15e0390fe9b7725e47b3"
+version = "30.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
 dependencies = [
  "anyhow",
  "bitflags 2.7.0",
  "bumpalo",
  "cc",
  "cfg-if 1.0.0",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
  "indexmap 2.7.0",
  "libc",
- "libm",
  "log",
  "mach2",
  "memfd",
@@ -3622,14 +3607,15 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "sptr",
- "target-lexicon",
- "wasmparser 0.221.2",
+ "target-lexicon 0.13.1",
+ "wasmparser 0.223.0",
  "wasmtime-asm-macros",
  "wasmtime-component-macro",
  "wasmtime-cranelift",
  "wasmtime-environ",
  "wasmtime-fiber",
  "wasmtime-jit-icache-coherence",
+ "wasmtime-math",
  "wasmtime-slab",
  "wasmtime-versioned-export-macros",
  "wasmtime-winch",
@@ -3638,18 +3624,16 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882a18800471cfc063c8b3ccf75723784acc3fd534009ac09421f2fac2fcdcec"
+version = "30.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
 dependencies = [
  "cfg-if 1.0.0",
 ]
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5c0a77c9e1927c3d471f53cc13767c3d3438e5d5ffd394e3eb31c86445fd60"
+version = "30.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -3662,44 +3646,42 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43702ca98bf5162eca0573db691ed9ecd36d716f8c6688410fe26ec16b6f9bcb"
+version = "30.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20070aa5b75080a8932ec328419faf841df2bc6ceb16b55b0df2b952098392a2"
+version = "30.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
- "cranelift-codegen 0.115.0",
- "cranelift-control 0.115.0",
- "cranelift-entity 0.115.0",
- "cranelift-frontend 0.115.0",
+ "cranelift-codegen 0.117.0",
+ "cranelift-control 0.117.0",
+ "cranelift-entity 0.117.0",
+ "cranelift-frontend 0.117.0",
  "cranelift-native",
  "gimli 0.31.1",
  "itertools 0.12.1",
  "log",
  "object 0.36.7",
+ "pulley-interpreter",
  "smallvec",
- "target-lexicon",
+ "target-lexicon 0.13.1",
  "thiserror 1.0.69",
- "wasmparser 0.221.2",
+ "wasmparser 0.223.0",
  "wasmtime-environ",
  "wasmtime-versioned-export-macros",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2604ddb24879d4dc1dedcb7081d7a8e017259bce916fdae097a97db52cbaab80"
+version = "30.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
 dependencies = [
  "anyhow",
- "cranelift-bitset 0.115.0",
- "cranelift-entity 0.115.0",
+ "cranelift-bitset 0.117.0",
+ "cranelift-entity 0.117.0",
  "gimli 0.31.1",
  "indexmap 2.7.0",
  "log",
@@ -3708,17 +3690,16 @@ dependencies = [
  "serde",
  "serde_derive",
  "smallvec",
- "target-lexicon",
- "wasm-encoder 0.221.2",
- "wasmparser 0.221.2",
+ "target-lexicon 0.13.1",
+ "wasm-encoder",
+ "wasmparser 0.223.0",
  "wasmprinter",
 ]
 
 [[package]]
 name = "wasmtime-fiber"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98593412d2b167ebe2b59d4a17a184978a72f976b53b3a0ec05629451079ac1d"
+version = "30.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
 dependencies = [
  "anyhow",
  "cc",
@@ -3731,9 +3712,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40d7722b9e1fbeae135715710a8a2570b1e6cf72b74dd653962d89831c6c70d"
+version = "30.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -3742,16 +3722,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmtime-math"
+version = "30.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "wasmtime-slab"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8579c335220b4ece9aa490a0e8b46de78cd342b195ab21ff981d095e14b52383"
+version = "30.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7de0a56fb0a69b185968f2d7a9ba54750920a806470dff7ad8de91ac06d277e"
+version = "30.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3760,16 +3746,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abd309943c443f5590d12f9aba9ba63c481091c955a0a14de0c2a9e0e3aaeca9"
+version = "30.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
 dependencies = [
  "anyhow",
- "cranelift-codegen 0.115.0",
+ "cranelift-codegen 0.117.0",
  "gimli 0.31.1",
  "object 0.36.7",
- "target-lexicon",
- "wasmparser 0.221.2",
+ "target-lexicon 0.13.1",
+ "wasmparser 0.223.0",
  "wasmtime-cranelift",
  "wasmtime-environ",
  "winch-codegen",
@@ -3777,9 +3762,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "969f83022dac3435d6469edb582ceed04cfe32aa44dc3ef16e5cb55574633df8"
+version = "30.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
 dependencies = [
  "anyhow",
  "heck",
@@ -3797,7 +3781,7 @@ dependencies = [
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.223.0",
+ "wasm-encoder",
 ]
 
 [[package]]
@@ -3891,17 +3875,17 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9110decc2983ed94de904804dcd979ba59cbabc78a94fec6b1d8468ec513d0f6"
+version = "30.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#a6a08570216d5c42b1c1fc9699fe5b9ae214f27e"
 dependencies = [
  "anyhow",
- "cranelift-codegen 0.115.0",
+ "cranelift-codegen 0.117.0",
  "gimli 0.31.1",
  "regalloc2 0.11.1",
  "smallvec",
- "target-lexicon",
- "wasmparser 0.221.2",
+ "target-lexicon 0.13.1",
+ "thiserror 1.0.69",
+ "wasmparser 0.223.0",
  "wasmtime-cranelift",
  "wasmtime-environ",
 ]
@@ -4074,9 +4058,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.221.2"
+version = "0.223.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbe1538eea6ea5ddbe5defd0dc82539ad7ba751e1631e9185d24a931f0a5adc8"
+checksum = "92772f4dcacb804b275981eea1d920b12b377993b53307f1e33d87404e080281"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -4087,7 +4071,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.221.2",
+ "wasmparser 0.223.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,12 +25,17 @@ tinywasm = "0.8.0"
 wasmer = { version = "5.0", default-features = false, features = ["engine", "compiler"] }
 wasmer-compiler-singlepass = "5.0"
 wasmer-compiler-cranelift = "5.0"
-wasmtime = { version = "28.0.0", default-features = false, features = ["winch", "cranelift", "runtime"] }
 makepad-stitch = "0.1.0"
 criterion = "0.5"
 wat = "1"
 serde_json = "1.0.117"
 plotters = "0.3.7"
+
+[dependencies.wasmtime]
+git = "https://github.com/bytecodealliance/wasmtime"
+branch = "main"
+default-features = false
+features = ["winch", "cranelift", "pulley", "runtime"]
 
 [dependencies.wasm3]
 git = "https://github.com/robbepop/wasm3-rs.git"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,7 @@ serde_json = "1.0.117"
 plotters = "0.3.7"
 
 [dependencies.wasmtime]
-git = "https://github.com/bytecodealliance/wasmtime"
-branch = "main"
+version = "29.0.0"
 default-features = false
 features = ["winch", "cranelift", "pulley", "runtime"]
 

--- a/src/plot.rs
+++ b/src/plot.rs
@@ -21,6 +21,7 @@ pub enum VmAndConfig {
     Stitch,
     WasmtimeCranelift,
     WasmtimeWinch,
+    WasmtimePulley,
     WasmerCranelift,
     WasmerSinglepass,
 }
@@ -41,6 +42,7 @@ impl VmAndConfig {
             VmAndConfig::Stitch => "Stitch (lazy)",
             VmAndConfig::WasmtimeCranelift => "Wasmtime (Cranelift)",
             VmAndConfig::WasmtimeWinch => "Wasmtime (Winch)",
+            VmAndConfig::WasmtimePulley => "Wasmtime (Pulley)",
             VmAndConfig::WasmerCranelift => "Wasmer (Cranelift)",
             VmAndConfig::WasmerSinglepass => "Wasmer (Singlepass)",
         }
@@ -58,7 +60,9 @@ impl VmAndConfig {
             Self::Tinywasm => RGBColor(108, 140, 108),
             Self::Wasm3 | Self::Wasm3Lazy => RGBColor(90, 90, 90),
             Self::Stitch => RGBColor(220, 175, 180),
-            Self::WasmtimeCranelift | Self::WasmtimeWinch => RGBColor(140, 120, 160),
+            Self::WasmtimeCranelift | Self::WasmtimeWinch | Self::WasmtimePulley => {
+                RGBColor(140, 120, 160)
+            }
             Self::WasmerCranelift | Self::WasmerSinglepass => RGBColor(95, 140, 175),
         }
     }
@@ -81,6 +85,7 @@ impl FromStr for VmAndConfig {
             "stitch" => Ok(Self::Stitch),
             "wasmtime.cranelift" => Ok(Self::WasmtimeCranelift),
             "wasmtime.winch" => Ok(Self::WasmtimeWinch),
+            "wasmtime.pulley" => Ok(Self::WasmtimePulley),
             "wasmer.cranelift" => Ok(Self::WasmerCranelift),
             "wasmer.singlepass" => Ok(Self::WasmerSinglepass),
             _ => Err(FromStrError::from(format!("invalid VmAndConfig: {input}"))),

--- a/src/vms/mod.rs
+++ b/src/vms/mod.rs
@@ -4,7 +4,7 @@ pub use self::wasm3::Wasm3;
 pub use self::wasmer::Wasmer;
 pub use self::wasmi_new::WasmiNew;
 pub use self::wasmi_old::WasmiOld;
-pub use self::wasmtime::Wasmtime;
+pub use self::wasmtime::{Wasmtime, Strategy as WasmtimeStrategy};
 use crate::utils::TestFilter;
 use ::wasmi_new::ModuleImportsIter;
 
@@ -78,10 +78,13 @@ pub fn vms_under_test() -> Vec<Box<dyn BenchVm>> {
         }),
         Box::new(Stitch),
         Box::new(Wasmtime {
-            strategy: ::wasmtime::Strategy::Cranelift,
+            strategy: WasmtimeStrategy::Cranelift,
         }),
         Box::new(Wasmtime {
-            strategy: ::wasmtime::Strategy::Winch,
+            strategy: WasmtimeStrategy::Winch,
+        }),
+        Box::new(Wasmtime {
+            strategy: WasmtimeStrategy::Pulley,
         }),
         Box::new(Wasmer {
             compiler: wasmer::WasmerCompiler::Cranelift,

--- a/src/vms/mod.rs
+++ b/src/vms/mod.rs
@@ -4,7 +4,7 @@ pub use self::wasm3::Wasm3;
 pub use self::wasmer::Wasmer;
 pub use self::wasmi_new::WasmiNew;
 pub use self::wasmi_old::WasmiOld;
-pub use self::wasmtime::{Wasmtime, Strategy as WasmtimeStrategy};
+pub use self::wasmtime::{Strategy as WasmtimeStrategy, Wasmtime};
 use crate::utils::TestFilter;
 use ::wasmi_new::ModuleImportsIter;
 

--- a/src/vms/wasmtime.rs
+++ b/src/vms/wasmtime.rs
@@ -54,7 +54,13 @@ impl BenchVm for Wasmtime {
                     },
                 }
             }
-            Strategy::Pulley => TestFilter::default(),
+            Strategy::Pulley => TestFilter {
+                execute: ExecuteTestFilter::default(),
+                compile: CompileTestFilter {
+                    ffmpeg: false,
+                    ..CompileTestFilter::default()
+                },
+            },
         }
     }
 
@@ -100,10 +106,7 @@ impl BenchVm for Wasmtime {
 impl Wasmtime {
     fn store(&self) -> wasmtime::Store<()> {
         let mut config = wasmtime::Config::default();
-        if matches!(
-            self.strategy,
-            Strategy::Cranelift
-        ) {
+        if matches!(self.strategy, Strategy::Cranelift) {
             config.wasm_tail_call(true);
         }
         config.strategy(match self.strategy {


### PR DESCRIPTION
Wasm Coremark Scores using `cargo run --profile bench`:
```json
{
  "wasmtime.cranelift": 12723,
  "wasmer.cranelift": 12802,
  "wasmer.singlepass": 12756,
  "stitch": 3059,
  "wasm3.eager": 2933,
  "wasm3.lazy": 2894,
  "wasmi-new.lazy.checked": 2040,
  "wasmi-new.eager.checked": 2039,
  "wasmtime.pulley": 932,
  "wasmi-old": 895,
  "tinywasm": 528,
}
```