### PR TITLE
Update VM configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The following Wasm runtimes and configurations are included.
 | Runtime | ID | Configurations | Note |
 |:-------:|:---------------|:-----|:---|
 | [Wasmi v0.31] | `wasmi-v0.31` | | The old version of the Wasmi Wasm interpreter. |
-| [Wasmi v0.32] | `wasmi-v0.32` | `eager`, `eager.unchecked`, `lazy`, `lazy.unchecked`, `lazy-translation` | New Wasmi Wasm interpreter version with major updates. |
+| [Wasmi (recent)] | `wasmi-v0.32` | `eager`, `eager.unchecked`, `lazy`, `lazy.unchecked`, `lazy-translation` | New Wasmi Wasm interpreter version with major updates. |
 | [Tinywasm] | `tinywasm` | | Very tiny zero-dependencies Wasm interpreter. |
 | [Wasm3] | `wasm3` | `eager`, `lazy` | A very fast well-established Wasm interpreter. |
 | [Wasmtime] | `wasmtime` | `cranelift`, `winch`, `pulley` | Well established Wasm JIT runtime with cutting edge Wasm features. Winch only works on `x86` platforms. |
@@ -19,7 +19,7 @@ The following Wasm runtimes and configurations are included.
 Ideally we had more Wasm runtimes, e.g. [WAMR], [Toywasm] and [Wain] but those had no proper Rust bindings or sufficiently flexible APIs respectively.
 
 [Wasmi v0.31]: https://github.com/wasmi-labs/wasmi/tree/v0.31.2
-[Wasmi v0.32]: https://github.com/wasmi-labs/wasmi
+[Wasmi (recent)]: https://github.com/wasmi-labs/wasmi
 [WAMR]: https://github.com/bytecodealliance/wasm-micro-runtime
 [Toywasm]: https://github.com/yamt/toywasm
 [Wain]: https://github.com/rhysd/wain

--- a/src/vms/mod.rs
+++ b/src/vms/mod.rs
@@ -65,10 +65,6 @@ pub fn vms_under_test() -> Vec<Box<dyn BenchVm>> {
             compilation_mode: ::wasmi_new::CompilationMode::Lazy,
             validation: Validation::Unchecked,
         }),
-        Box::new(WasmiNew {
-            compilation_mode: ::wasmi_new::CompilationMode::LazyTranslation,
-            validation: Validation::Checked,
-        }),
         Box::new(Tinywasm),
         Box::new(Wasm3 {
             compilation_mode: wasm3::CompilationMode::Eager,

--- a/src/vms/mod.rs
+++ b/src/vms/mod.rs
@@ -54,8 +54,8 @@ pub fn vms_under_test() -> Vec<Box<dyn BenchVm>> {
             validation: Validation::Checked,
         }),
         Box::new(WasmiNew {
-            compilation_mode: ::wasmi_new::CompilationMode::Eager,
-            validation: Validation::Unchecked,
+            compilation_mode: ::wasmi_new::CompilationMode::LazyTranslation,
+            validation: Validation::Checked,
         }),
         Box::new(WasmiNew {
             compilation_mode: ::wasmi_new::CompilationMode::Lazy,

--- a/src/vms/wasm3.rs
+++ b/src/vms/wasm3.rs
@@ -25,10 +25,11 @@ impl BenchVm for Wasm3 {
     }
 
     fn test_filter(&self) -> TestFilter {
+        let execute = matches!(self.compilation_mode, CompilationMode::Lazy);
         TestFilter {
             execute: ExecuteTestFilter {
                 fib_tailrec: false,
-                ..Default::default()
+                ..ExecuteTestFilter::set_to(execute)
             },
             ..Default::default()
         }

--- a/src/vms/wasmi_new.rs
+++ b/src/vms/wasmi_new.rs
@@ -42,10 +42,7 @@ impl BenchVm for WasmiNew {
         // since we do not expect them to have significantly different behavior compared to
         // `eager.checked` and `lazy.checked`.
         let execute = matches!(self.validation, Validation::Checked)
-            && matches!(
-                self.compilation_mode,
-                CompilationMode::Eager | CompilationMode::Lazy
-            );
+            && matches!(self.compilation_mode, CompilationMode::Eager);
         TestFilter {
             execute: ExecuteTestFilter::set_to(execute),
             ..TestFilter::set_to(true)


### PR DESCRIPTION
- Remove `wasmi.eager.unchecked` config
- Swap `wasmi.eager.checked` and `wasmi.lazy-translation.checked` configs
- Run execution benchmarks only for `wasmi.eager.checked`.
- Run execution benchmarks only for `wasm3.lazy` which is its default.