### PR TITLE
Try to fix Wasmer CI check failure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,8 +16,6 @@ jobs:
         name: Build
         runs-on: ubuntu-latest
         steps:
-          - name: Install GCC multilib + unwind support
-            run: sudo apt-get update && sudo apt-get install -y gcc-multilib libunwind-dev
           - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
           - uses: dtolnay/rust-toolchain@stable
           - name: Set up Rust cache

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,8 @@ jobs:
         name: Build
         runs-on: ubuntu-latest
         steps:
+          - name: Install GCC multilib + unwind support
+            run: sudo apt-get update && sudo apt-get install -y gcc-multilib libunwind-dev
           - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
           - uses: dtolnay/rust-toolchain@stable
           - name: Set up Rust cache

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,6 +498,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
+name = "compiler_builtins"
+version = "0.1.160"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6376049cfa92c0aa8b9ac95fae22184b981c658208d4ed8a1dc553cd83612895"
+dependencies = [
+ "rustc-std-workspace-core",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2547,6 +2556,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustc-std-workspace-core"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9c45b374136f52f2d6311062c7146bff20fec063c3f5d46a410bd937746955"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3471,6 +3486,7 @@ dependencies = [
 name = "wasmi-benchmarks"
 version = "0.1.0"
 dependencies = [
+ "compiler_builtins",
  "criterion",
  "makepad-stitch",
  "plotters",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ criterion = "0.7"
 wat = "1"
 serde_json = "1.0.117"
 plotters = "0.3.7"
+compiler_builtins = { version = "0.1", features = ["rustc-dep-of-std"] } # Required to fix Wasmer build on CI
 
 [dependencies.wasmtime]
 version = "35.0.0"


### PR DESCRIPTION
Trying to fix this Wasmer issue: https://github.com/rust-lang/rust/issues/143835#issuecomment-3065131901

```
error: linking with `cc` failed: exit status: 1
  |
  = note:  "cc" "-m64" "/tmp/rustceYS9yD/symbols.o" "<3 object files omitted>" "-Wl,--as-needed" "-Wl,-Bstatic" "/home/runner/work/wasmi-benchmarks/wasmi-benchmarks/target/debug/deps/{libserde_json-076c85aa28bef719.rlib,libitoa-279da08f248c98b3.rlib,libryu-246d81c0b9350367.rlib,libwasmi_benchmarks-2c57b6fbd929368e.rlib,libwasmtime-f6157367b07d099d.rlib,libwasmtime_internal_winch-cddec14df3103f88.rlib,libwinch_codegen-4b668943cf982dbc.rlib,libwasmtime_internal_cranelift-8db4006a6d94d4cc.rlib,libcranelift_native-70db5246b3bf8eba.rlib,libitertools-4b21d54adfdd3e58.rlib,libcranelift_frontend-03072cde3630fad7.rlib,libmemfd-7c29464decb73d3c.rlib,librustix-28665070b85bd1f6.rlib,liblinux_raw_sys-80dddc84290d5516.rlib,librustix-7f5b258784afa0b2.rlib,liblinux_raw_sys-cf9deda150587d58.rlib,libwasmtime_internal_unwinder-b40fb76b03e169d7.rlib,libcranelift_codegen-5e0f2d222a61947e.rlib,libpulley_interpreter-769374be91c3c458.rlib,libwasmtime_internal_math-a8ef4e5607677e48.rlib,liblibm-f9b5baa7c21295c9.rlib,libcranelift_assembler_x64-02b77f7d51e48618.rlib,libcranelift_codegen_shared-d9bca1dbecf80061.rlib,libregalloc2-2eb0838283bc3910.rlib,librustc_hash-52a8a9295c049815.rlib,libcranelift_control-3a840b2a121003b9.rlib,libcranelift_bforest-142b7eb9623e73de.rlib,libwasmtime_internal_slab-33b71bf785e32772.rlib,libwasmtime_internal_jit_icache_coherence-e01dbefeeb13a999.rlib,libwasmtime_environ-f9060adcca9bd8ba.rlib,libpostcard-c3fe444c9a9a926c.rlib,libcobs-675fba4fb784eecc.rlib,libthiserror-e5f0710fc3832209.rlib,libcranelift_entity-0468d110c3cb8b17.rlib,libcranelift_bitset-13bd4059d82f8b9e.rlib,libtarget_lexicon-8bd264355c17f423.rlib,libwasmparser-9f32be3c9cbeabe3.rlib,libanyhow-1e10034e2102936b.rlib,libwasmi-9157154472f4d063.rlib,libwasmparser_nostd-af129047aac2ba50.rlib,libindexmap_nostd-720910993b1246d5.rlib,libwasmi_arena-cb7a927f8392a3fd.rlib,libwasmi_core-9dc97d8eb668a65d.rlib,libnum_traits-1fc26a34301fc1c2.rlib,libdowncast_rs-744a60b15733431f.rlib,libwasmer_compiler_singlepass-5afe35cc82a28cb9.rlib,libdynasmrt-f573f511c29afd6b.rlib,libmemmap2-0c39339c4d395f92.rlib,libwasmer_compiler_cranelift-9a79e69f7ce744ae.rlib,libitertools-2fb590906896ae89.rlib,libcranelift_frontend-0edbc223af3abab7.rlib,librayon-847e47ccf9655ae5.rlib,librayon_core-a8076a5c791e1abb.rlib,libcrossbeam_deque-9e206e90e8ab30ea.rlib,libcrossbeam_epoch-629993dafed22acb.rlib,libeither-f2ee0bd57c9254b2.rlib,libcranelift_codegen-55191d4ea2e8f56c.rlib,libcranelift_codegen_shared-2beb95c354a64548.rlib,libregalloc2-7b3fcef6e049294e.rlib,libslice_group_by-de6b97be20bd7a2a.rlib,libhashbrown-15f653c0e0f85a54.rlib,librustc_hash-ee8634a3d88746eb.rlib,libgimli-aaa705e50224668a.rlib,libfallible_iterator-b08cb24fdc8a93e2.rlib,libstable_deref_trait-d94d61e36fec08c9.rlib,libcranelift_control-dd945377c942e037.rlib,libarbitrary-e45327406837330b.rlib,libcranelift_bforest-610048ea5d78d8be.rlib,libcranelift_entity-358c00f6a6693243.rlib,libcranelift_bitset-56de3bdcdc394018.rlib,libwasm3-4b1ffb7255d46403.rlib,libwasm3_sys-a568904e758d5262.rlib,libcty-24a08808fe6aaf9b.rlib,libtinywasm-2a314822cb9b79dd.rlib,libtinywasm_parser-70c3494c1aac904a.rlib,libwasmparser-6c6a4dbd6a6fa6f5.rlib,libsemver-13a6e480db3e3cf6.rlib,libtinywasm_types-edb9ec7453fa8115.rlib,librkyv-6580bdf07e2060f3.rlib,librend-d2b7e99ad6960473.rlib,libhashbrown-25db77b94a5cc1de.rlib,libahash-166b2d76c2e6094c.rlib,libgetrandom-af4ce4773aa34b27.rlib,libseahash-cc738c5f84bdc78d.rlib,libbytecheck-b236ffd17c9eee9f.rlib,libptr_meta-f1bf10d755af15e8.rlib,liblog-4f4206fe6116746a.rlib,libwasmer-534634a803ce038a.rlib,libderive_more-b14e9b38b7e15bef.rlib,libtracing-8c8980e5173d463c.rlib,libpin_project_lite-1d755b3840df7e98.rlib,libtracing_core-a144c30bc1c0e9ba.rlib,libwasmer_compiler-a12047cdad53c38b.rlib,libself_cell-7d4b9c21a7cf9d9b.rlib,libobject-6b9d2b2b449fced0.rlib,libruzstd-444344817c80bf23.rlib,libtwox_hash-7160847931433c6a.rlib,libstatic_assertions-e8a10ee10f76f6d5.rlib,libbyteorder-062995684a6c8fcd.rlib,libflate2-75e5d9df4a588e4a.rlib,libshared_buffer-e8ddfb5df7dea962.rlib,libmemmap2-c25c3a9bb1b17860.rlib,libwasmer_vm-ce7f028de7e5ba05.rlib,libcrossbeam_queue-de4c42d78f3857d7.rlib,libregion-47c86fd5cfd7d9a3.rlib,libbitflags-a22b3815edb19765.rlib,liblibunwind-2062799383783cb5.rlib,libcorosensei-9a3696ee5ce6a37a.rlib,libbacktrace-f41a2731000a3993.rlib,libminiz_oxide-f0c5f1b962caa71e.rlib,libsimd_adler32-a11f99ebcf53a8b2.rlib,libobject-0eb5dbf24d8e011f.rlib,libcrc32fast-f4afb6b9748f66d3.rlib,libaddr2line-50bc08c907ab69d5.rlib,libgimli-89ffea70e96873c5.rlib,librustc_demangle-cae45e4e8cc91aa1.rlib,libfnv-d345c3b6b0c06fa0.rlib,libdashmap-5354fa1853efba72.rlib,liblock_api-795495f3ab2b463a.rlib,libscopeguard-e442faa98418a5aa.rlib,libhashbrown-9047308ed8f2be6a.rlib,libahash-5b78443cebf75262.rlib,libzerocopy-ebde873ad10573e1.rlib,libonce_cell-6250cb6c6ed7eff2.rlib,libcrossbeam_utils-65d35f29fc20c490.rlib,libparking_lot_core-ece817c2d4875dd7.rlib,liblibc-71790f9d1886d0cd.rlib,libsmallvec-d288d25f500c9b59.rlib,libmemoffset-49e9f5770a32c4c2.rlib,libwasmparser-dab01146f6d32646.rlib,libwasmer_types-4d4fff8d5f29731d.rlib,libxxhash_rust-1f877e733a9ee109.rlib,libhex-be50539266bc789b.rlib,libmore_asserts-edb11e1067aed8e8.rlib,libtarget_lexicon-57d6e04c4f0c19a4.rlib,libenumset-3df761a300a75e44.rlib,libsha2-72d97b48f3fdd733.rlib,libcpufeatures-06cfd6948c2251b9.rlib,libcfg_if-15f425b386a12ee0.rlib,libdigest-8721071c45cb713c.rlib,libsubtle-e8efba37df48d853.rlib,libblock_buffer-6dd5f810052f5155.rlib,libcrypto_common-c005fdcdd05c9b8b.rlib,libgeneric_array-7d02e743f89437bb.rlib,libtypenum-653d15b0c1873368.rlib,libenum_iterator-40dcfa6d8c05563b.rlib,librkyv-20649f277ef3ad7e.rlib,libindexmap-09d034abc35dc6cd.rlib,libequivalent-64e1eb2b595b618d.rlib,libserde-4de2b913b5044454.rlib,libhashbrown-847ff0c2716e244a.rlib,libfoldhash-e2faec953e98cf44.rlib,librend-8b708ec060c4a02c.rlib,libmunge-d1f680e0f55bb831.rlib,libbytecheck-a4c3d382c67c5c70.rlib,libsimdutf8-6c84cb75321f0da2.rlib,librancor-1fa944b25d4427f8.rlib,libptr_meta-48ca464b59d4ce38.rlib,libthiserror-65b68f008a1896bf.rlib,libbytes-185591eb0ad692e5.rlib,libmakepad_stitch-c24e606fab7f6fa0.rlib,libwasmi-23a4f1adc5f81546.rlib,libwasmi_ir-917b273ab232911d.rlib,libwasmi_collections-6cad75916e774434.rlib,libwat-00365349fb6afa8d.rlib,libwast-f9f783c0bf2f737a.rlib,libmemchr-e44710ea7fc613d2.rlib,libwasm_encoder-d2076b130be3d195.rlib,libleb128fmt-091ace4302910f87.rlib,libunicode_width-6180b694e22f74e9.rlib,libbumpalo-8973b8f193088ef4.rlib,liballocator_api2-d5e3685d65973eb3.rlib,libwasmi_core-c3b3f3577c48ca58.rlib,libwasmparser-b83c89112c186547.rlib,libbitflags-aa8aaeca36770332.rlib,libspin-cbb2970e2fd22c73.rlib}.rlib" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib/{libstd-*,libpanic_unwind-*,libobject-*,libmemchr-*,libaddr2line-*,libgimli-*,librustc_demangle-*,libstd_detect-*,libhashbrown-*,librustc_std_workspace_alloc-*,libminiz_oxide-*,libadler2-*,libunwind-*,libcfg_if-*,liblibc-*,librustc_std_workspace_core-*,liballoc-*,libcore-*,libcompiler_builtins-*}.rlib" "-Wl,-Bdynamic" "-lgcc_s" "-lutil" "-lrt" "-lpthread" "-lm" "-ldl" "-lc" "-L" "/tmp/rustceYS9yD/raw-dylibs" "-Wl,--eh-frame-hdr" "-Wl,-z,noexecstack" "-L" "/home/runner/work/wasmi-benchmarks/wasmi-benchmarks/target/debug/build/wasm3-sys-273abf1a7e1f9241/out" "-L" "/home/runner/work/wasmi-benchmarks/wasmi-benchmarks/target/debug/build/wasmer-5a7091259b68130e/out/build" "-L" "/home/runner/work/wasmi-benchmarks/wasmi-benchmarks/target/debug/build/wasmtime-a8d9b90b571d147e/out" "-L" "/usr/lib/x86_64-linux-gnu" "-L" "/usr/lib/x86_64-linux-gnu" "-L" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-o" "/home/runner/work/wasmi-benchmarks/wasmi-benchmarks/target/debug/deps/coremark-36450e63440d60aa" "-Wl,--gc-sections" "-pie" "-Wl,-z,relro,-z,now" "-nodefaultlibs"
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: /usr/bin/ld: /home/runner/work/wasmi-benchmarks/wasmi-benchmarks/target/debug/deps/libwasmer_vm-ce7f028de7e5ba05.rlib(wasmer_vm-ce7f028de7e5ba05.wasmer_vm.11b12892c68e41af-cgu.11.rcgu.o): in function `wasmer_vm::libcalls::function_pointer':
          /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/wasmer-vm-6.0.1/src/libcalls.rs:(.text._ZN9wasmer_vm8libcalls16function_pointer17h1e62fb693467c37dE+0x126): undefined reference to `__rust_probestack'
          collect2: error: ld returned 1 exit status
          
  = note: some `extern` functions couldn't be found; some native libraries may need to be installed or have their path specified
  = note: use the `-l` flag to specify native libraries to link
  = note: use the `cargo:rustc-link-lib` directive to specify the native libraries to link with Cargo (see https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-link-lib)

error: could not compile `wasmi-benchmarks` (bin "coremark") due to 1 previous error
Error: Process completed with exit code 101.
```